### PR TITLE
(vite plugin) 정적 개발환경에서 hmr을 거치기 전 adorable css를 적용받을 수 있도록 plugin 내 entry object 세팅

### DIFF
--- a/src[vite-plugin-adorable-css]/src/vite-plugin-adorable-css.ts
+++ b/src[vite-plugin-adorable-css]/src/vite-plugin-adorable-css.ts
@@ -4,12 +4,15 @@ import {createGenerateCss, parseAtoms, PrefixRules, Rules} from "./atomizer"
 import {reset} from "./rules"
 
 import micromatch from "micromatch"
+import {readFileSync} from 'fs'
+import {join} from 'path'
 
 interface Config {
   include:string[]
   reset:string
   rules:Rules
   prefixRules:PrefixRules
+  preLoads:string[]
 }
 
 const ADORABLE_CSS = "@adorable.css"
@@ -21,7 +24,8 @@ const CONFIG:Config = {
   include: ["**/*.{svelte,tsx,jsx,vue,mdx,svx,html}"],
   reset,
   rules: {},
-  prefixRules: {}
+  prefixRules: {},
+  preLoads: []
 }
 
 export const adorableCSS = (config?:Partial<Config>):Plugin[] => {
@@ -97,6 +101,16 @@ export const adorableCSS = (config?:Partial<Config>):Plugin[] => {
           debounceInvalidate()
         }
         return next()
+      })
+    },
+
+    buildStart: () => {
+      const {preLoads} = config
+      preLoads.forEach((currentPath) => {
+        const path = join(configRoot, currentPath)
+        const file = readFileSync(path, 'utf-8')
+
+        entry[path] = parseAtoms(file)
       })
     },
 


### PR DESCRIPTION
테오 안녕하세요~!
덕분에 adorable css랑 피그마 플러그인 잘 사용하고있습니다 감사합니다!

좀 특이한 경우이긴 할 것 같은데, 제가 개발중인 sdk가 vanilla + 정적 html 파일 모음으로만 구성되어있는데 
이런 경우에는 vite plugin이 현재 구조상 handleHotUpdate를 타기 전까지
reset 외에 다른 속성들을 적용받지 못하는 현상이 있었습니다~!

(첫 실행 후 파일 수정이 일어나기 전까지 adorable css 속성이 적용되지 않습니다!)

https://stackblitz.com/edit/vite-5zey7v?file=index.html
요 링크는 유사한 예시 환경인데, 말씀드린대로 첫 로딩엔 adorable css 속성 적용을 받지 못하다가,
파일 수정 후 handleHotUpdate를 타는 순간부터 적용되는 것을 볼 수 있습니다

그래서 임시로 hmr을 거치기 전 adorable css를 적용받을을 정적파일을 명시할 수 있도록 preLoads라는 옵션을 만들어보았는데 한번 검토 부탁드려요~!

(혹시 entry를 초기화할 다른 방법이 있다면 조언 부탁드려요!)