### PR TITLE
package.json 경로 오류

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -26,14 +26,14 @@
   },
   "exports": {
     ".": {
-      "require": "./index.js",
-      "import": "./index.js",
-      "types": "./index.d.ts"
+      "require": "./dist/index.js",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./vite": {
-      "require": "./vite/index.js",
-      "import": "./vite/index.js",
-      "types": "./vite/index.d.ts"
+      "require": "./dist/vite/index.js",
+      "import": "./dist/vite/index.js",
+      "types": "./dist/vite/index.d.ts"
     }
   }
 }


### PR DESCRIPTION
package.json의 경로 오류 수정입니다.

그런데 이렇게 설정할 경우 vscode에서 모듈을 찾을 수 없다고 하는데 따로 설정해야 하는게 있나요?
실행은 정상적으로 됩니다.
