### PR TITLE
페이지에서 콘텐츠가 잘리지 않도록 수정

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,7 +10,7 @@
   <meta property="og:site_name" content="ฅ^•ﻌ•^ฅ ♥ AdorableCSS"/>
   <meta property="og:type" content="object"/>
   <meta property="og:title" content="AdorableCSS"/>
-  <meta property="og:description" content="CSS를 쓾 필요 없는 세상 귀여운 CSS 프레임워크!"/>
+  <meta property="og:description" content="CSS를 쓸 필요 없는 세상 귀여운 CSS 프레임워크!"/>
 
   <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"/>
   %sveltekit.head%

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-const slide = "text-center vbox pack p(200/32) max-h(60vh) odd:bg(#f9f9f9) clip"
+const slide = "text-center vbox pack p(200/32) odd:bg(#f9f9f9) clip"
 const h1 = "font(3em/-/-1.5%) bold ~md:font(1.6em)"
 const h2 = "font(1.2em/-/-1.5%) c(#555) ~md:font(1.4em)"
 </script>
 
-<div class="{slide} gap(40)">
+<div class="{slide} gap(40) max-h(60vh)">
   <div class="hbox font(80/-/-15%) AppleSD opacity(0.7) hover:scale(1.05) hover:opacity(1) transition(.4s) pointer group">
     <span class="group-hover:rotate(-10deg) group-active:rotate(10deg) transition(.4s)">ฅ</span>
     <span>^•ﻌ•^</span>


### PR DESCRIPTION
* 메인 페이지의 일부 콘텐츠가 잘려서 제대로 보이지 않는 문제가 있어요.
* 새롭게 추가된 max-h() 클래스가 모든 콘텐츠를 감싼 요소에 적용되어 있어 발생하는 문제로 파악했어요.
* 영역이 잘리지않도록 `slide` 에서 max-h() 클래스를 제거했어요.
* description 메타 태그에 오타가 있어서 수정했어요.

https://developer-1px.github.io/adorable-css

# As-Is
<img width="2672" alt="Screenshot 2023-09-12 at 11 15 47 AM" src="https://github.com/developer-1px/adorable-css/assets/48359052/cdfa9fb3-d3d0-44b2-a80e-dd8acf859c27">

# To-Be
<img width="2672" alt="Screenshot 2023-09-12 at 11 34 05 AM" src="https://github.com/developer-1px/adorable-css/assets/48359052/02f6ce3d-f61e-4b67-b98f-6ddde9544721">
