### PR TITLE
docs:header + home:header 오탈자 수정

### DIFF
--- a/packages/vite/docs/Docs.md
+++ b/packages/vite/docs/Docs.md
@@ -23,7 +23,7 @@ CSS가 어려운 이유는 뭘까요? 그것은 바로 이름짓기 문제입니
 
 또한 ```.nav__title``` ```.nav__title--selected``` 어떤 식으로 구조를 짜야하는지 늘 혼란스러워 합니다.
 
-### No more writing own your CSS!
+### No more writing your own CSS!
 
 그렇다면 아예 CSS를 작성하지 않는 방법은 어떨까요?
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,7 +18,7 @@ const h2 = "font(1.2em/-/-1.5%) c(#555) ~md:font(1.4em)"
 </div>
 
 <div class="{slide}">
-  <h1 class="{h1}">No more writing own your CSS.</h1>
+  <h1 class="{h1}">No more writing your own CSS.</h1>
   <h2 class="{h2}">We have created almost all the CSS you need. Just write down in your HTML(or JSX).</h2>
   <div class="space(2em)"/>
   <img src="https://images.velog.io/images/teo/post/dde8bc56-15d0-4fc0-a15a-f3c204f50494/AdorableCSS.gif"/>


### PR DESCRIPTION
홈과 문서 페이지에서 사용된 헤더 (h1, h3)에 영문 오탈자가 보여서 수정한 PR입니다. 

**Before:**
"No more writing own your CSS."

**After:**
"No more writing your own CSS."

홈 - https://developer-1px.github.io/adorable-css/
문서 - https://developer-1px.github.io/adorable-css/docs